### PR TITLE
fixed link for MIRAS and added second link to CCHP 2020 paper

### DIFF
--- a/H0_tension_plots/README.md
+++ b/H0_tension_plots/README.md
@@ -13,8 +13,9 @@ If you use this plot, do not forget to also properly cite each of the individual
  * <a href="https://ui.adsabs.harvard.edu/abs/2018MNRAS.480.3879A/abstract"> DES Year 1 results</a>, using clustering and weak lensing in combination with BAO and BBN. 
  * <a href="https://ui.adsabs.harvard.edu/abs/2020arXiv200204035P/abstract"> Philcox et al. (2020)</a>, using Full-Shape and BAO analyses in the BOSS survey in combination with BBN.
  * <a href="https://ui.adsabs.harvard.edu/abs/2019ApJ...876...85R/abstract">  SH0ES</a>, using the distance ladder method with SNe Ia and Cepheids. 
- * <a href="https://ui.adsabs.harvard.edu/abs/2019ApJ...882...34F/abstract"> CCHP</a>, using the distance ladder method with SNe Ia and the Tip of the Red Giand Branch. 
- * <a href="https://ui.adsabs.harvard.edu/abs/2019ApJ...876...85R/abstract"> MIRAS</a>, using the distance ladder method with SNIe Ia and Mira variables 
+ * <a href="https://ui.adsabs.harvard.edu/abs/2019ApJ...882...34F/abstract"> CCHP 2019</a>, <a href="https://ui.adsabs.harvard.edu/abs/2020ApJ...891...57F/abstract"> CCHP 2020</a>, 
+ , using the distance ladder method with SNe Ia and the Tip of the Red Giand Branch. 
+ * <a href="https://ui.adsabs.harvard.edu/abs/2020ApJ...889....5H/abstract"> MIRAS</a>, using the distance ladder method with SNIe Ia and Mira variables 
  * <a href="https://ui.adsabs.harvard.edu/abs/2019arXiv190704869W/abstract"> H0LiCOW 6-lenses results</a>, using time-delay cosmography in lensed quasars
  * <a href="https://ui.adsabs.harvard.edu/abs/2020ApJ...891L...1P/abstract"> MCP</a>, using water megamasers
  * <a href="https://ui.adsabs.harvard.edu/abs/2018AAS...23231902P/abstract"> SBF</a>, using Surface Brightness Fluctuation and Cepheids


### PR DESCRIPTION
The MIRAS link was pointing towards the SH0ES paper. I also added the CCHP 2020 paper on the link but did not change the (very minor) difference in their values. You don't need to merge the PR but I want to make sure we are in sync when updating the plot.